### PR TITLE
a repetition of the word "by"

### DIFF
--- a/ch02/01_main-chapter-code/ch02.ipynb
+++ b/ch02/01_main-chapter-code/ch02.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "source": [
     "- Load raw text we want to work with\n",
-    "- [The Verdict by by Edith Wharton](https://en.wikisource.org/wiki/The_Verdict) is a public domain short story"
+    "- [The Verdict by Edith Wharton](https://en.wikisource.org/wiki/The_Verdict) is a public domain short story"
    ]
   },
   {


### PR DESCRIPTION
"The Verdict by by Edith Wharton" contains a repetition of the word "by." The correct form should be "The Verdict by Edith Wharton."