### PR TITLE
fix move model to device before calculating loss

### DIFF
--- a/appendix-D/01_main-chapter-code/appendix-D.ipynb
+++ b/appendix-D/01_main-chapter-code/appendix-D.ipynb
@@ -425,6 +425,7 @@
     "\n",
     "torch.manual_seed(123)\n",
     "model = GPTModel(GPT_CONFIG_124M)\n",
+    "model.to(device)\n",
     "\n",
     "loss = calc_loss_batch(input_batch, target_batch, model, device)\n",
     "loss.backward()"


### PR DESCRIPTION
In the Appendix D notebook if you are using a GPU the gradient clipping loss calculation fails due to the model not being in the device.