### PR TITLE
Fix an incorrect input dimension

### DIFF
--- a/ch03/01_main-chapter-code/multihead-attention.ipynb
+++ b/ch03/01_main-chapter-code/multihead-attention.ipynb
@@ -228,7 +228,7 @@
     "            [CausalSelfAttention(d_in, d_out, context_length, dropout, qkv_bias) \n",
     "             for _ in range(num_heads)]\n",
     "        )\n",
-    "        self.out_proj = nn.Linear(d_out*num_heads, d_out*num_heads)\n",
+    "        self.out_proj = nn.Linear(d_in*num_heads, d_out*num_heads)\n",
     "\n",
     "    def forward(self, x):\n",
     "        context_vec = torch.cat([head(x) for head in self.heads], dim=-1)\n",
@@ -383,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/ch03/01_main-chapter-code/multihead-attention.ipynb
+++ b/ch03/01_main-chapter-code/multihead-attention.ipynb
@@ -38,7 +38,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "torch version: 2.2.1\n"
+      "torch version: 2.2.2\n"
      ]
     }
    ],
@@ -228,7 +228,7 @@
     "            [CausalSelfAttention(d_in, d_out, context_length, dropout, qkv_bias) \n",
     "             for _ in range(num_heads)]\n",
     "        )\n",
-    "        self.out_proj = nn.Linear(d_in*num_heads, d_out*num_heads)\n",
+    "        self.out_proj = nn.Linear(d_out*num_heads, d_out*num_heads)\n",
     "\n",
     "    def forward(self, x):\n",
     "        context_vec = torch.cat([head(x) for head in self.heads], dim=-1)\n",
@@ -365,6 +365,14 @@
     "\n",
     "print(\"context_vecs.shape:\", context_vecs.shape)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1d965a5-9b98-4554-8646-7ecd497874cb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -383,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/ch03/02_bonus_efficient-multihead-attention/mha-implementations.ipynb
+++ b/ch03/02_bonus_efficient-multihead-attention/mha-implementations.ipynb
@@ -341,7 +341,7 @@
     "        self.d_out = d_out\n",
     "\n",
     "        self.qkv = nn.Linear(d_in, 3 * d_out, bias=qkv_bias)\n",
-    "        self.proj = nn.Linear(d_in, d_out)\n",
+    "        self.proj = nn.Linear(d_out, d_out)\n",
     "        self.dropout = dropout\n",
     "\n",
     "    def forward(self, x):\n",


### PR DESCRIPTION
Most likely, it's just a typo. What makes it tricky is, the code in its existing form would still work perfectly well, as long as  the input and output dimensions match. But when `d_in != d_out`, we would have a problem.