### PR TITLE
Fixed possibly wrong token ids in ch05.ipynb

### DIFF
--- a/ch05/01_main-chapter-code/ch05.ipynb
+++ b/ch05/01_main-chapter-code/ch05.ipynb
@@ -290,7 +290,7 @@
     "                       [40,    1107, 588]])   #  \"I really like\"]\n",
     "\n",
     "targets = torch.tensor([[3626, 6100, 345  ],  # [\" effort moves you\",\n",
-    "                        [588,  428,  11311]]) #  \" really like chocolate\"]"
+    "                        [1107,  588, 11311]]) #  \" really like chocolate\"]"
    ]
   },
   {


### PR DESCRIPTION
Assuming gpt2 tokenizer is used

```
import tiktoken

tokenizer = tiktoken.get_encoding("gpt2")

print(tokenizer.encode("every effort moves"))
print("---")
print(tokenizer.encode(" effort moves you"))
# [16833, 3626, 6100]
# ---
# [3626, 6100, 345]

print(tokenizer.encode("I really like"))
print("---")
print(tokenizer.encode(" really like chocolate"))
# [40, 1107, 588]
# ---
# [1107, 588, 11311] <- was [588, 428, 11311] earlier, which doesn't make sense when trying to highlight the shifting nature of target