### PR TITLE
fix typos, add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+default_stages: [commit]
+
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        name: codespell
+        description: Checks for common misspellings in text files.
+        entry: codespell --skip="*.bpe,*.json" -L "ocassion,occassion,ot,te,tje"
+        language: python
+        types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+# A tool used by developers to identify spelling errors in text.
+# Readers may ignore this file.
+
 default_stages: [commit]
 
 repos:
@@ -6,7 +9,9 @@ repos:
     hooks:
       - id: codespell
         name: codespell
-        description: Checks for common misspellings in text files.
-        entry: codespell --skip="*.bpe,*.json" -L "ocassion,occassion,ot,te,tje"
+        description: Check for spelling errors in text.
+        entry: codespell
         language: python
-        types: [text]
+        args:
+          - "-L ocassion,occassion,ot,te,tje"
+        files: \.txt$|\.md$|\.py|\.ipynb$

--- a/ch03/02_bonus_efficient-multihead-attention/mha-implementations.ipynb
+++ b/ch03/02_bonus_efficient-multihead-attention/mha-implementations.ipynb
@@ -317,7 +317,7 @@
     "id": "f78e346f-3b85-44e6-9feb-f01131381148"
    },
    "source": [
-    "- The implementation below uses PyTorch's [`scaled_dot_product_attention`](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) function, which implements a memory-optimized version of self-attention calld [flash attention](https://arxiv.org/abs/2205.14135)"
+    "- The implementation below uses PyTorch's [`scaled_dot_product_attention`](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) function, which implements a memory-optimized version of self-attention called [flash attention](https://arxiv.org/abs/2205.14135)"
    ]
   },
   {

--- a/ch04/01_main-chapter-code/ch04.ipynb
+++ b/ch04/01_main-chapter-code/ch04.ipynb
@@ -1043,7 +1043,7 @@
    "id": "dec7d03d-9ff3-4ca3-ad67-01b67c2f5457",
    "metadata": {},
    "source": [
-    "- We are almost there: now let's plug in the transformer block into the architecture we coded at the very beginning of this chapter so that we obtain a useable GPT architecture\n",
+    "- We are almost there: now let's plug in the transformer block into the architecture we coded at the very beginning of this chapter so that we obtain a usable GPT architecture\n",
     "- Note that the transformer block is repeated multiple times; in the case of the smallest 124M GPT-2 model, we repeat it 12 times:"
    ]
   },

--- a/ch06/02_bonus_additional-experiments/additional-experiments.py
+++ b/ch06/02_bonus_additional-experiments/additional-experiments.py
@@ -370,7 +370,7 @@ if __name__ == "__main__":
         action='store_true',
         default=False,
         help=(
-            "Disable padding, which means each example may have a different lenght."
+            "Disable padding, which means each example may have a different length."
             " This requires setting `--batch_size 1`."
         )
     )

--- a/ch07/02_dataset-utilities/create-passive-voice-entries.ipynb
+++ b/ch07/02_dataset-utilities/create-passive-voice-entries.ipynb
@@ -166,7 +166,7 @@
     "    return response.choices[0].message.content\n",
     "\n",
     "\n",
-    "# Prepare intput\n",
+    "# Prepare input\n",
     "sentence = \"I ate breakfast\"\n",
     "prompt = f\"Convert the following sentence to passive voice: '{sentence}'\"\n",
     "run_chatgpt(prompt, client)"


### PR DESCRIPTION
This PR fixes a few typos found with [`codespell`](https://github.com/codespell-project/codespell/tree/master). 

It also includes a [pre-commit](https://pre-commit.com/) hook that checks for typos on every commit. 

The words behind the [`-L` flag](https://github.com/codespell-project/codespell/tree/master?tab=readme-ov-file#ignoring-words) are words that codespell needs to ignore. 

The word `Ocassion` for example is used in the [chapter 7 notebook](https://github.com/rasbt/LLMs-from-scratch/blob/main/ch07/01_main-chapter-code/ch07.ipynb) in the following context

```
Example entry:
 {'instruction': 'Identify the correct spelling of the following word.', 'input': 'Ocassion', 'output': "The correct spelling is 'Occasion.'"}
 ```
 
 so needs to remain unchanged.
 
 Let me know if you don't like this pre-commit hook and I'll remove it from this PR.