### PR TITLE
47,678-->48,725

### DIFF
--- a/ch05/01_main-chapter-code/ch05.ipynb
+++ b/ch05/01_main-chapter-code/ch05.ipynb
@@ -743,7 +743,7 @@
    "id": "71ae26dd-d77e-41fd-b924-6bd103dd4ee7",
    "metadata": {},
    "source": [
-    "- The perplexity is often considered more interpretable because it can be understood as the effective vocabulary size that the model is uncertain about at each step (in the example above, that'd be 50,257 words or tokens)\n",
+    "- The perplexity is often considered more interpretable because it can be understood as the effective vocabulary size that the model is uncertain about at each step (in the example above, that'd be 48,725 words or tokens)\n",
     "- In other words, perplexity provides a measure of how well the probability distribution predicted by the model matches the actual distribution of the words in the dataset\n",
     "- Similar to the loss, a lower perplexity indicates that the model predictions are closer to the actual distribution"
    ]

--- a/ch05/01_main-chapter-code/ch05.ipynb
+++ b/ch05/01_main-chapter-code/ch05.ipynb
@@ -743,7 +743,7 @@
    "id": "71ae26dd-d77e-41fd-b924-6bd103dd4ee7",
    "metadata": {},
    "source": [
-    "- The perplexity is often considered more interpretable because it can be understood as the effective vocabulary size that the model is uncertain about at each step (in the example above, that'd be 47,678 words or tokens)\n",
+    "- The perplexity is often considered more interpretable because it can be understood as the effective vocabulary size that the model is uncertain about at each step (in the example above, that'd be 50,257 words or tokens)\n",
     "- In other words, perplexity provides a measure of how well the probability distribution predicted by the model matches the actual distribution of the words in the dataset\n",
     "- Similar to the loss, a lower perplexity indicates that the model predictions are closer to the actual distribution"
    ]


### PR DESCRIPTION
~~if I not misunderstand, should it be the vocab size? the probability distribute across the whole vocab and sum to 1. Each step has the number of vocab's size choice.~~

the number `47,678` or `47678`  can't be found in context, so I think maybe it's a misspelled number.  Given the context of **effective vocabulary size**, and ppl is 48725.8203, should it be 48,725?