### PR TITLE
Update matplotlib tests on Windows

### DIFF
--- a/.github/workflows/basic-tests-windows.yml
+++ b/.github/workflows/basic-tests-windows.yml
@@ -37,6 +37,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest nbval
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install matplotlib==3.9.0
 
       - name: Test Selected Python Scripts
         shell: bash


### PR DESCRIPTION
Windows seems to behave weirdly and shows matplotlib version 0.0. Let's see if this fixes it.