### PR TITLE
Fix incorrect argument name in LlamaTokenizer constructor

### DIFF
--- a/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
+++ b/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
@@ -1216,7 +1216,7 @@
     "\n",
     "\n",
     "class LlamaTokenizer:\n",
-    "    def __init__(self, filepath):\n",
+    "    def __init__(self, tokenizer_file):\n",
     "        sp = spm.SentencePieceProcessor()\n",
     "        sp.load(tokenizer_file)\n",
     "        self.tokenizer = sp\n",


### PR DESCRIPTION
This PR addresses an oversight in the LlamaTokenizer class by changing the constructor argument from filepath to tokenizer_file. This correction clarifies the purpose of the argument and enhances code readability.