### PR TITLE
add GPT2TokenizerFast to BPE comparison

### DIFF
--- a/ch02/02_bonus_bytepair-encoder/compare-bpe-tiktoken.ipynb
+++ b/ch02/02_bonus_bytepair-encoder/compare-bpe-tiktoken.ipynb
@@ -180,8 +180,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fetching encoder.json: 1.04Mit [00:00, 3.47Mit/s]                                                   \n",
-      "Fetching vocab.bpe: 457kit [00:00, 2.07Mit/s]                                                       \n"
+      "Fetching encoder.json: 1.04Mit [00:00, 4.13Mit/s]                                                   \n",
+      "Fetching vocab.bpe: 457kit [00:00, 2.56Mit/s]                                                       \n"
      ]
     }
    ],
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "a6233552",
    "metadata": {},
    "outputs": [],
@@ -320,10 +320,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "fa5ca643",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[15496, 11, 995, 13, 1148, 428, 438, 257, 1332, 30]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "hf_tokenizer_fast(strings)[\"input_ids\"]"
    ]
@@ -341,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "b6e6b1a5-9dc0-4b20-9a8b-c02aa0e3191c",
    "metadata": {},
    "outputs": [],
@@ -387,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "04fbd764-ec98-44f1-9b0a-e9db9a3bb91e",
    "metadata": {},
    "outputs": [],
@@ -404,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "5a5def88-1d2c-4550-a5e8-ee82b72b92d7",
    "metadata": {},
    "outputs": [
@@ -435,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "a61bb445-b151-4a2f-8180-d4004c503754",
    "metadata": {},
    "outputs": [],
@@ -454,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "57f7c0a3-c1fd-4313-af34-68e78eb33653",
    "metadata": {},
    "outputs": [
@@ -462,7 +473,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.44 ms ± 54 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "3.39 ms ± 21.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -480,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "036dd628-3591-46c9-a5ce-b20b105a8062",
    "metadata": {},
    "outputs": [
@@ -488,7 +499,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.08 ms ± 4.69 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
+      "1.08 ms ± 5.99 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
      ]
     }
    ],
@@ -506,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "b9c85b58-bfbc-465e-9a7e-477e53d55c90",
    "metadata": {},
    "outputs": [
@@ -521,7 +532,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10.3 ms ± 180 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "10.2 ms ± 115 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -531,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "7117107f-22a6-46b4-a442-712d50b3ac7a",
    "metadata": {},
    "outputs": [
@@ -539,7 +550,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10.2 ms ± 72.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "10 ms ± 36.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -549,22 +560,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "da57c95a",
+   "execution_count": 25,
+   "id": "d6bfc7f0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Token indices sequence length is longer than the specified maximum sequence length for this model (5145 > 1024). Running this sequence through the model will result in indexing errors\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.79 ms ± 48.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
    "source": [
-    "%timeit hf_tokenizer_fast(raw_text, max_length=5145, truncation=True)[\"input_ids\"]"
+    "%timeit hf_tokenizer_fast(raw_text)[\"input_ids\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d6bfc7f0",
+   "execution_count": 26,
+   "id": "da57c95a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.83 ms ± 58.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
    "source": [
-    "%timeit hf_tokenizer_fast(raw_text)[\"input_ids\"]"
+    "%timeit hf_tokenizer_fast(raw_text, max_length=5145, truncation=True)[\"input_ids\"]"
    ]
   },
   {
@@ -577,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "id": "3b4ff4d5-f2d9-4ea6-a51c-023dbba15429",
    "metadata": {},
    "outputs": [
@@ -585,7 +619,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.74 ms ± 48.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
+      "1.59 ms ± 11.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
      ]
     }
    ],

--- a/ch02/02_bonus_bytepair-encoder/compare-bpe-tiktoken.ipynb
+++ b/ch02/02_bonus_bytepair-encoder/compare-bpe-tiktoken.ipynb
@@ -307,6 +307,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6233552",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import GPT2TokenizerFast\n",
+    "\n",
+    "hf_tokenizer_fast = GPT2TokenizerFast.from_pretrained(\"gpt2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa5ca643",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_tokenizer_fast(strings)[\"input_ids\"]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9d0f2e95-8ae8-4606-a8e0-b0fce91cfac9",
    "metadata": {},
@@ -523,6 +545,26 @@
    ],
    "source": [
     "%timeit hf_tokenizer(raw_text, max_length=5145, truncation=True)[\"input_ids\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da57c95a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit hf_tokenizer_fast(raw_text, max_length=5145, truncation=True)[\"input_ids\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6bfc7f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit hf_tokenizer_fast(raw_text)[\"input_ids\"]"
    ]
   },
   {

--- a/ch07/01_main-chapter-code/exercise-solutions.ipynb
+++ b/ch07/01_main-chapter-code/exercise-solutions.ipynb
@@ -309,7 +309,30 @@
     "Average score: 48.87\n",
     "```\n",
     "\n",
-    "The score is close to 50, which is in the same ballpark as the score we previously achieved with the Alpaca-style prompts."
+    "The score is close to 50, which is in the same ballpark as the score we previously achieved with the Alpaca-style prompts.\n",
+    "\n",
+    "There is no inherent advantage or rationale why the Phi prompt-style should be better, but it can be more concise and efficient, except for the caveat mentioned in the *Tip* section below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "156bc574-3f3e-4479-8f58-c8c8c472416e",
+   "metadata": {},
+   "source": [
+    "#### Tip: Considering special tokens"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65cacf90-21c2-48f2-8f21-5c0c86749ff2",
+   "metadata": {},
+   "source": [
+    "- Note that the Phi-3 prompt template contains special tokens such as `<|user|>` and `<|assistant|>`, which can be suboptimal for the GPT-2 tokenizer\n",
+    "- While the GPT-2 tokenizer recognizes `<|endoftext|>` as a special token (encoded into token ID 50256), it is inefficient at handling other special tokens, such as the aforementioned ones\n",
+    "- For instance, `<|user|>` is encoded into 5 individual token IDs (27, 91, 7220, 91, 29), which is very inefficient\n",
+    "- We could add `<|user|>` as a new special token in `tiktoken` via the `allowed_special` argument, but please keep in mind that the GPT-2 vocabulary would not be able to handle it without additional modification\n",
+    "- If you are curious about how a tokenizer and LLM can be extended to handle special tokens, please see the [extend-tiktoken.ipynb](../../ch05/09_extending-tokenizers/extend-tiktoken.ipynb) bonus materials (note that this is not required here but is just an interesting/bonus consideration for curious readers)\n",
+    "- Furthermore, we can hypothesize that models that support these special tokens of a prompt template via their vocabulary may perform more efficiently and better overall"
    ]
   },
   {
@@ -994,7 +1017,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/ch07/01_main-chapter-code/exercise-solutions.ipynb
+++ b/ch07/01_main-chapter-code/exercise-solutions.ipynb
@@ -309,30 +309,7 @@
     "Average score: 48.87\n",
     "```\n",
     "\n",
-    "The score is close to 50, which is in the same ballpark as the score we previously achieved with the Alpaca-style prompts.\n",
-    "\n",
-    "There is no inherent advantage or rationale why the Phi prompt-style should be better, but it can be more concise and efficient, except for the caveat mentioned in the *Tip* section below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "156bc574-3f3e-4479-8f58-c8c8c472416e",
-   "metadata": {},
-   "source": [
-    "#### Tip: Considering special tokens"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "65cacf90-21c2-48f2-8f21-5c0c86749ff2",
-   "metadata": {},
-   "source": [
-    "- Note that the Phi-3 prompt template contains special tokens such as `<|user|>` and `<|assistant|>`, which can be suboptimal for the GPT-2 tokenizer\n",
-    "- While the GPT-2 tokenizer recognizes `<|endoftext|>` as a special token (encoded into token ID 50256), it is inefficient at handling other special tokens, such as the aforementioned ones\n",
-    "- For instance, `<|user|>` is encoded into 5 individual token IDs (27, 91, 7220, 91, 29), which is very inefficient\n",
-    "- We could add `<|user|>` as a new special token in `tiktoken` via the `allowed_special` argument, but please keep in mind that the GPT-2 vocabulary would not be able to handle it without additional modification\n",
-    "- If you are curious about how a tokenizer and LLM can be extended to handle special tokens, please see the [extend-tiktoken.ipynb](../../ch05/09_extending-tokenizers/extend-tiktoken.ipynb) bonus materials (note that this is not required here but is just an interesting/bonus consideration for curious readers)\n",
-    "- Furthermore, we can hypothesize that models that support these special tokens of a prompt template via their vocabulary may perform more efficiently and better overall"
+    "The score is close to 50, which is in the same ballpark as the score we previously achieved with the Alpaca-style prompts."
    ]
   },
   {
@@ -1017,7 +994,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* adds `GPT2TokenizerFast` from HuggingFace `transformers` to `compare-bpe-tiktoken.ipynb`, see https://github.com/rasbt/LLMs-from-scratch/discussions/485#discussioncomment-11893357

(please generate output to make it consistent with other BPE implementations' outputs)