### PR TITLE
Fix default argument in ex 7.2

### DIFF
--- a/ch07/01_main-chapter-code/exercise_experiments.py
+++ b/ch07/01_main-chapter-code/exercise_experiments.py
@@ -541,7 +541,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exercise_solution",
         type=str,
-        default="last_block",
+        default="baseline",
         help=(
             f"Which experiment to run. Options: {options}."
         )


### PR DESCRIPTION
Fixes a default argument issue where an error would be raised if no command line argument is provided. Fixes #505 