### PR TITLE
Fix typo in Ch02 comments

### DIFF
--- a/ch02/01_main-chapter-code/ch02.ipynb
+++ b/ch02/01_main-chapter-code/ch02.ipynb
@@ -46,7 +46,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "torch version: 2.4.0\n",
+      "torch version: 2.5.1\n",
       "tiktoken version: 0.7.0\n"
      ]
     }
@@ -1252,7 +1252,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyTorch version: 2.4.0\n"
+      "PyTorch version: 2.5.1\n"
      ]
     }
    ],
@@ -1791,7 +1791,7 @@
     "print(token_embeddings.shape)\n",
     "\n",
     "# uncomment & execute the following line to see how the embeddings look like\n",
-    "# print(token_embedding)"
+    "# print(token_embeddings)"
    ]
   },
   {


### PR DESCRIPTION
Simple typo fix where it said

```python
# uncomment & execute the following line to see how the embeddings look like
# print(input_embedding)
```

instead of

```python
# uncomment & execute the following line to see how the embeddings look like
# print(input_embeddings)
```

Fixes #515