### PR TITLE
Mention small discrepancy due to Dropout non-reproducibility in PyTorch

### DIFF
--- a/.github/workflows/basic-tests-old-pytorch.yml
+++ b/.github/workflows/basic-tests-old-pytorch.yml
@@ -1,4 +1,4 @@
-name: Test PyTorch 2.0 and 2.5
+name: Test PyTorch 2.0 and 2.6
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pytorch-version: [ 2.0.1, 2.5.0 ]
+        pytorch-version: [ 2.0.1, 2.6.0 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/ch04/01_main-chapter-code/ch04.ipynb
+++ b/ch04/01_main-chapter-code/ch04.ipynb
@@ -317,6 +317,7 @@
     "```\n",
     "\n",
     "- Since these are just random numbers, this is not a reason for concern, and you can proceed with the remainder of the chapter without issues\n",
+    "- One possible reason for this discrepancy is the differing behavior of `nn.Dropout` across operating systems, depending on how PyTorch was compiled, as discussed [here on the PyTorch issue tracker](https://github.com/pytorch/pytorch/issues/121595)\n",
     "\n",
     "---"
    ]

--- a/ch05/01_main-chapter-code/ch05.ipynb
+++ b/ch05/01_main-chapter-code/ch05.ipynb
@@ -1349,6 +1349,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2e8b86f0-b07d-40d7-b9d3-a9218917f204",
+   "metadata": {},
+   "source": [
+    "- Note that you might get slightly different loss values on your computer, which is not a reason for concern if they are roughly similar (a training loss below 1 and a validation loss below 7)\n",
+    "- Small differences can often be due to different GPU hardware and CUDA versions or small changes in newer PyTorch versions\n",
+    "- Even if you are running the example on a CPU, you may observe slight differences; a possible reason for a discrepancy is the differing behavior of `nn.Dropout` across operating systems, depending on how PyTorch was compiled, as discussed [here on the PyTorch issue tracker](https://github.com/pytorch/pytorch/issues/121595)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 28,
    "id": "0WSRu2i0iHJE",


### PR DESCRIPTION
Adds a note explaining that the non-deterministic Dropout behavior (see [PyTorch Issue tracker](https://github.com/pytorch/pytorch/issues/121595)) can explain discrepancies.