### PR TITLE
Used -1, -2 for transpose to avoid hardcoding dimensions.

### DIFF
--- a/ch03/01_main-chapter-code/multihead-attention.ipynb
+++ b/ch03/01_main-chapter-code/multihead-attention.ipynb
@@ -315,7 +315,7 @@
     "        values = values.transpose(1, 2)\n",
     "\n",
     "        # Compute scaled dot-product attention (aka self-attention) with a causal mask\n",
-    "        attn_scores = queries @ keys.transpose(2, 3)  # Dot product for each head\n",
+    "        attn_scores = queries @ keys.transpose(-2, -1)  # Dot product for each head\n",
     "        \n",
     "        # Original mask truncated to the number of tokens and converted to boolean\n",
     "        mask_bool = self.mask.bool()[:num_tokens, :num_tokens]\n",


### PR DESCRIPTION
Used -1, -2 for transpose to avoid hardcoding dimensions.2,3 dimension is hardcoded. if you have multiple dimension then it wont work but using -1,-2 it will always work.