### PR TITLE
Comment that DDP-script.py does not work with GPUs > 2

### DIFF
--- a/appendix-A/01_main-chapter-code/DDP-script.py
+++ b/appendix-A/01_main-chapter-code/DDP-script.py
@@ -179,6 +179,8 @@ def compute_accuracy(model, dataloader, device):
 
 
 if __name__ == "__main__":
+    # This script may not work for GPUs > 2 due to the small dataset
+    # Run `CUDA_VISIBLE_DEVICES=0,1 python DDP-script.py` if you have GPUs > 2
     print("PyTorch version:", torch.__version__)
     print("CUDA available:", torch.cuda.is_available())
     print("Number of GPUs available:", torch.cuda.device_count())


### PR DESCRIPTION
I first tried running DDP-script.py on a node with 8 GPUs and was getting ZeroDivisionError (total_examples being 0). Apparently, this is because the dataset is small, so if there are more than two processes, then some processes will have no batches.

The book mentions that the code works for two GPUs but I wasn't expecting it to fail with more GPUs. Suggesting a comment that may save someone's time. 