### PR TITLE
Add BPE from scratch link

### DIFF
--- a/ch02/README.md
+++ b/ch02/README.md
@@ -13,3 +13,5 @@
 - [03_bonus_embedding-vs-matmul](03_bonus_embedding-vs-matmul) contains optional (bonus) code to explain that embedding layers and fully connected layers applied to one-hot encoded vectors are equivalent.
 
 - [04_bonus_dataloader-intuition](04_bonus_dataloader-intuition) contains optional (bonus) code to explain the data loader more intuitively with simple numbers rather than text.
+
+- [05_bpe-from-scratch](05_bpe-from-scratch) contains (bonus) code that implements and trains a GPT-2 BPE tokenizer from scratch.


### PR DESCRIPTION
Adds a link to the readme to refer to the BPE from scratch code.