### PR TITLE
Add a note about "zsh: illegal hardware instruction python" error

### DIFF
--- a/ch05/01_main-chapter-code/ch05.ipynb
+++ b/ch05/01_main-chapter-code/ch05.ipynb
@@ -2185,6 +2185,16 @@
    "id": "ff76a736-6f9f-4328-872e-f89a7b70a2cc",
    "metadata": {},
    "source": [
+    "---\n",
+    "\n",
+    "**Note**\n",
+    "\n",
+    "- In very rare cases, the code cell above may result in a `zsh: illegal hardware instruction python` error, which could be due to a TensorFlow installation issue on your machine\n",
+    "- A reader found that installing TensorFlow via `conda` solved the issue in this specific case, as mentioned [here](https://github.com/rasbt/LLMs-from-scratch/discussions/273#discussioncomment-12367888)\n",
+    "- You can find more instructions in this supplementary [Python setup tutorial](https://github.com/rasbt/LLMs-from-scratch/tree/main/setup/01_optional-python-setup-preferences#option-2-using-conda)\n",
+    "\n",
+    "---\n",
+    "\n",
     "- We can then download the model weights for the 124 million parameter model as follows:"
    ]
   },


### PR DESCRIPTION
Adds a note about a potential error message a user was encountering [here](https://github.com/rasbt/LLMs-from-scratch/discussions/273#discussioncomment-12367888).