### PR TITLE
Dpo vocab size clarification

### DIFF
--- a/ch07/04_preference-tuning-with-dpo/dpo-from-scratch.ipynb
+++ b/ch07/04_preference-tuning-with-dpo/dpo-from-scratch.ipynb
@@ -2140,7 +2140,7 @@
    },
    "source": [
     "- In other words, `torch.gather` is a selection function\n",
-    "- When we computed the loss earlier, we used it to retrieve the log probabilities corresponding to the correct token in the 50,256-token vocabulary\n",
+    "- When we computed the loss earlier, we used it to retrieve the log probabilities corresponding to the correct token in the 50,257-token vocabulary\n",
     "- The \"correct\" tokens are the tokens given in the response entry"
    ]
   },
@@ -3112,7 +3112,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3126,7 +3126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/ch07/README.md
+++ b/ch07/README.md
@@ -1,4 +1,4 @@
-# Chapter 7: Finetuning to Follow Instructions
+# 	Chapter 7: Finetuning to Follow Instructions
 
 &nbsp;
 ## Main Chapter Code
@@ -13,12 +13,3 @@
 - [04_preference-tuning-with-dpo](04_preference-tuning-with-dpo) implements code for preference finetuning with Direct Preference Optimization (DPO)
 - [05_dataset-generation](05_dataset-generation) contains code to generate and improve synthetic datasets for instruction finetuning
 - [06_user_interface](06_user_interface) implements an interactive user interface to interact with the pretrained LLM
-
-
-
-
-
-<br>
-<br>
-
-[![Link to the video](https://img.youtube.com/vi/4yNswvhPWCQ/0.jpg)](https://www.youtube.com/watch?v=4yNswvhPWCQ)

--- a/ch07/README.md
+++ b/ch07/README.md
@@ -1,4 +1,4 @@
-# 	Chapter 7: Finetuning to Follow Instructions
+# Chapter 7: Finetuning to Follow Instructions
 
 &nbsp;
 ## Main Chapter Code
@@ -13,3 +13,12 @@
 - [04_preference-tuning-with-dpo](04_preference-tuning-with-dpo) implements code for preference finetuning with Direct Preference Optimization (DPO)
 - [05_dataset-generation](05_dataset-generation) contains code to generate and improve synthetic datasets for instruction finetuning
 - [06_user_interface](06_user_interface) implements an interactive user interface to interact with the pretrained LLM
+
+
+
+
+
+<br>
+<br>
+
+[![Link to the video](https://img.youtube.com/vi/4yNswvhPWCQ/0.jpg)](https://www.youtube.com/watch?v=4yNswvhPWCQ)


### PR DESCRIPTION
Minor typo fix in the note where it mistakenly said 50256 not 50257.

Fixes #618