### PR TITLE
Correct function name in package import

### DIFF
--- a/ch07/01_main-chapter-code/ch07.ipynb
+++ b/ch07/01_main-chapter-code/ch07.ipynb
@@ -1634,7 +1634,7 @@
     ")\n",
     "# Alternatively:\n",
     "# from llms_from_scratch.ch05 import (\n",
-    "#    generate_text_simple,\n",
+    "#    generate,\n",
     "#    text_to_token_ids,\n",
     "#    token_ids_to_text\n",
     "# )\n",


### PR DESCRIPTION
Commented-out code to import from `llms_from_scratch` package uses an incorrect function name. This PR fixes it.