### PR TITLE
fix: removed redundant arg for `plot_losses`

### DIFF
--- a/ch05/03_bonus_pretraining_on_gutenberg/pretraining_simple.py
+++ b/ch05/03_bonus_pretraining_on_gutenberg/pretraining_simple.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     )
 
     epochs_tensor = torch.linspace(0, args.n_epochs, len(train_losses))
-    plot_losses(epochs_tensor, tokens_seen, train_losses, val_losses, output_dir)
+    plot_losses(epochs_tensor, tokens_seen, train_losses, val_losses)
 
     torch.save(model.state_dict(), output_dir / "model_pg_final.pth")
     print(f"Maximum GPU memory allocated: {torch.cuda.max_memory_allocated() / 1e9:.2f} GB")


### PR DESCRIPTION
* In case someone fully trains the model 😉, I have removed the `output_dir` arg from `plot_losses` as it would return an error then.
* `plot_losses` only accepts the first 4 args:
https://github.com/rasbt/LLMs-from-scratch/blob/58b8672452248733a182c5669843bf097072317c/pkg/llms_from_scratch/ch05.py#L221