### PR TITLE
Fix bug in masking when kv cache is used.

### DIFF
--- a/ch04/03_kv-cache/gpt_with_kv_cache.py
+++ b/ch04/03_kv-cache/gpt_with_kv_cache.py
@@ -72,7 +72,9 @@ class MultiHeadAttention(nn.Module):
         attn_scores = queries @ keys.transpose(2, 3)  # Dot product for each head
 
         # Original mask truncated to the number of tokens and converted to boolean
-        mask_bool = self.mask.bool()[:num_tokens, :num_tokens]
+        num_tokens_Q = queries.shape[-2]
+        num_tokens_K = keys.shape[-2]
+        mask_bool = self.mask.bool()[:num_tokens_Q, :num_tokens_K]
 
         # Use the mask to fill attention scores
         attn_scores.masked_fill_(mask_bool, -torch.inf)


### PR DESCRIPTION
Thank you for creating this project, I learned a lot from it!

There seems to be a small bug during masking when kv cache is enabled:
- W/o kv cache, `mask_bool = self.mask.bool()[:num_tokens, :num_tokens]` yields to intended results.
- W/ kv cache, `num_tokens` would be set to 1, and `mask_bool` would be a tensor of shape (1, 1). However, we want the `mask_bool` to be a tensor of shape (1, num_tokens_K).

The following changes address this bug.

