### PR TITLE
Fix issue #684: Minor docstring edit

### DIFF
--- a/setup/02_installing-python-libraries/python_environment_check.py
+++ b/setup/02_installing-python-libraries/python_environment_check.py
@@ -65,9 +65,10 @@ def get_packages(pkgs):
 
 def get_requirements_dict():
     """
-    Parses requirements.txt and returns a dictionary mapping package names (lowercase)
-    to a specifier string (e.g. ">=2.18.0,<3.0"). It uses packaging.requirements.Requirement
-    to properly handle environment markers.
+    Parses requirements.txt and returns a dictionary mapping package names (in lowercase)
+    to specifier strings (e.g. ">=2.18.0,<3.0"). It uses the Requirement class from 
+    packaging.requirements to properly handle environment markers, and converts each object's
+    specifier to a string.
     """
 
     PROJECT_ROOT = dirname(realpath(__file__))


### PR DESCRIPTION
Fixes [#684](https://github.com/rasbt/LLMs-from-scratch/issues/684). 

In ```python_environment_check.py``` the docstring for the function ```get_requirements_dict``` uses the full import "packaging.requirements.Requirements" which can instead be explained as "the Requirement class from packaging.requirements."

The fix is minor but the discussion suggests some clarity can be helpful. The conversion of the object's specifier to a string is explicitly included. One minor grammatical error is fixed also. 

Applied fixes:
--- setup/02_installing-python-libraries/python_environment_check.py