### PR TITLE
Fix RoPE implementation

### DIFF
--- a/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
+++ b/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
@@ -83,9 +83,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "huggingface_hub version: 0.33.0\n",
+      "huggingface_hub version: 0.33.2\n",
       "sentencepiece version: 0.2.0\n",
-      "torch version: 2.6.0\n"
+      "torch version: 2.7.0\n"
      ]
     }
    ],
@@ -446,16 +446,15 @@
     "    assert head_dim % 2 == 0, \"Head dimension must be even\"\n",
     "\n",
     "    # Split x into first half and second half\n",
-    "    x1 = x[..., : head_dim // 2]  # First half\n",
-    "    x2 = x[..., head_dim // 2 :]  # Second half\n",
+    "    x1 = x[..., ::2]   # even\n",
+    "    x2 = x[..., 1::2]  # odd\n",
     "\n",
     "    # Adjust sin and cos shapes\n",
     "    cos = cos[:seq_len, :].unsqueeze(0).unsqueeze(0)  # Shape: (1, 1, seq_len, head_dim)\n",
     "    sin = sin[:seq_len, :].unsqueeze(0).unsqueeze(0)\n",
     "\n",
     "    # Apply the rotary transformation\n",
-    "    rotated = torch.cat((-x2, x1), dim=-1)\n",
-    "    x_rotated = (x * cos) + (rotated * sin)\n",
+    "    x_rotated = torch.stack([(x1*cos-x2*sin), (x1*sin + x2*cos)], dim=-1).flatten(-2)\n",
     "\n",
     "    return x_rotated.to(dtype=x.dtype)"
    ]

--- a/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
+++ b/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
@@ -964,8 +964,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "float32 (PyTorch default): 52.33 GB\n",
-      "bfloat16: 26.17 GB\n"
+      "float32 (PyTorch default): 52.27 GB\n",
+      "bfloat16: 26.13 GB\n"
      ]
     }
    ],
@@ -1093,7 +1093,15 @@
     "id": "3357a230-b678-4691-a238-257ee4e80185",
     "outputId": "768ed6af-ce14-40bc-ca18-117b4b448269"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Note: Environment variable`HF_TOKEN` is set and is the current active token independently from the token you've just configured.\n"
+     ]
+    }
+   ],
    "source": [
     "from huggingface_hub import login\n",
     "import json\n",
@@ -1216,7 +1224,7 @@
      "output_type": "stream",
      "text": [
       "Output text:\n",
-      " Every effort movesαllRadius deletingpretcc否']; future eer napulate lackус während inter DES издаSchéonkkarto Оryptato#{ningproof eerbye\n"
+      " Every effort movesαllRadius deletingpretccapped enoughxsnu writerSP similardomain generalized iconepнародзоtree Sebastiananti eer killometricRadiusotto MysCy без\n"
      ]
     }
    ],
@@ -1302,22 +1310,7 @@
     "id": "5fa9c06c-7a53-4b4d-9ce4-acc027322ee4",
     "outputId": "0d8942cc-e5e2-4e77-ec41-1ac7bec7d94f"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66e777955e8748df878f118f07f38dab",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "consolidated.00.pth:   0%|          | 0.00/13.5G [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "weights_file = hf_hub_download(\n",
     "   repo_id=\"meta-llama/Llama-2-7b\",\n",
@@ -1500,7 +1493,7 @@
      "output_type": "stream",
      "text": [
       "Output text:\n",
-      " Every effort has been made to ensure that the information contained in this website is accurate and up to date and correct at the time of publication\n"
+      " Every effort has been made to ensure the accuracy of the information contained in this website. However, the information contained in this website is provided\n"
      ]
     }
    ],
@@ -1540,7 +1533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 31,
    "id": "nbvAV7vaz6yc",
    "metadata": {
     "colab": {
@@ -1565,26 +1558,13 @@
    },
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3b2448a60f5f4ba5b2c686037c8ecd78",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "consolidated.00.pth:   0%|          | 0.00/13.5G [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Output text:\n",
       " What do llamas eat?\n",
-      "Llamas and alpacas are herbivores, which means they eat grasses, leaves, grass\n"
+      "\n",
+      "Llamas are herbivores, which means they eat plants for their food. They feed on a variety\n"
      ]
     }
    ],
@@ -1597,6 +1577,7 @@
     "   local_dir=\"Llama-2-7b-chat\"\n",
     ")\n",
     "\n",
+    "weights = torch.load(weights_file, weights_only=True)\n",
     "model = Llama2Model(LLAMA2_CONFIG_7B)\n",
     "load_weights_into_llama(model, LLAMA2_CONFIG_7B, weights)\n",
     "model.to(device);\n",

--- a/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
+++ b/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
@@ -434,9 +434,6 @@
     "    # Compute the angles\n",
     "    angles = positions[:, None] * inv_freq[None, :]  # Shape: (context_length, head_dim // 2)\n",
     "\n",
-    "    # Expand angles to match the head_dim\n",
-    "    angles = torch.cat([angles, angles], dim=1)  # Shape: (context_length, head_dim)\n",
-    "\n",
     "    # Precompute sine and cosine\n",
     "    cos = torch.cos(angles)\n",
     "    sin = torch.sin(angles)\n",
@@ -1659,7 +1656,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a PR to fix a bug in #746.

I found out that the output of RoPE did not match torchtune's [RotaryPositionalEmbeddings](https://docs.pytorch.org/torchtune/stable/generated/torchtune.modules.RotaryPositionalEmbeddings.html) or [llama's RoPE](https://github.com/meta-llama/llama/blob/main/llama/model.py#L80). 

After making changes to the RoPE implementation, the output from both Hugging Face and the notebook matched.

Here are the changes. Instead of dividing head into first half and second half by indexing up to half point, I indexed by even and odd. This is because even indexes are multiplied by cos and odd with sin. Then, I apply the following formula:
```
(a + bi) * (cos(θ) + i*sin(θ)) = (a*cos(θ) - b*sin(θ)) + i*(a*sin(θ) + b*cos(θ))
```
to apply RoPE transformation. 

I tried to follow your style of keeping cos and sin instead of converting them into complex numbers. 

I also found out that instruction-fintuned model weights were not getting loaded, so I added it.

Please let me know if some parts are unclear or needs changes. Thank you.