### PR TITLE
added brief explanations about  2 different ways of RoPE implementations

### DIFF
--- a/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
+++ b/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb
@@ -411,7 +411,9 @@
     "\n",
     "- Unlike traditional absolute positional embeddings, Llama uses rotary position embeddings (RoPE), which enable it to capture both absolute and relative positional information simultaneously\n",
     "- The reference paper for RoPE is [RoFormer: Enhanced Transformer with Rotary Position Embedding (2021)](https://arxiv.org/abs/2104.09864)\n",
-    "- This code uses the RoPE **split-halves** style, which matches the Hugging Face Transformers implementation ([modeling\\_llama.py](https://github.com/huggingface/transformers/blob/e42587f596181396e1c4b63660abf0c736b10dae/src/transformers/models/llama/modeling_llama.py#L173-L188)).<br> The original RoPE paper and Meta’s official LLaMA-2 repo, however, use the **interleaved (even/odd)** version ([llama/model.py](https://github.com/meta-llama/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/model.py#L64-L74)).<br> Both variants work fine — just be aware of this difference to avoid confusion."
+    "- RoPE can be implemented in two equivalent ways: the *split-halves* version and the *interleaved even/odd version*; they are mathematically the same as long as we pair dimensions consistently and use the same cos/sin ordering (see [this](https://github.com/rasbt/LLMs-from-scratch/issues/751) GitHub discussion for more information)\n",
+    "- This code uses the RoPE *split-halves* approach, similar to Hugging Face transformers ([modeling_llama.py](https://github.com/huggingface/transformers/blob/e42587f596181396e1c4b63660abf0c736b10dae/src/transformers/models/llama/modeling_llama.py#L173-L188))\n",
+    "- The original RoPE paper and Meta's official Llama 2 repository, however, use the *interleaved (even/odd)* version ([llama/model.py](https://github.com/meta-llama/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/model.py#L64-L74)); but as mentioned earlier, they are equivalent"
    ]
   },
   {


### PR DESCRIPTION
### Description

Thanks to the discussion in [issue #751](https://github.com/rasbt/LLMs-from-scratch/issues/751), this PR adds a short note in the [converting-gpt-to-llama2.ipynb](https://github.com/rasbt/LLMs-from-scratch/blob/main/ch05/07_gpt_to_llama/converting-gpt-to-llama2.ipynb) to highlight that there are **two different ways of implementing RoPE**:

- This code uses the RoPE **split-halves** style, which matches the Hugging Face Transformers implementation ([modeling\\_llama.py](https://github.com/huggingface/transformers/blob/e42587f596181396e1c4b63660abf0c736b10dae/src/transformers/models/llama/modeling_llama.py#L173-L188)).<br> The original RoPE paper and Meta’s official LLaMA-2 repo, however, use the **interleaved (even/odd)** version ([llama/model.py](https://github.com/meta-llama/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/model.py#L64-L74)).<br> Both variants work fine — just be aware of this difference to avoid confusion."

---

### Motivation

The discussion in [issue #751](https://github.com/rasbt/LLMs-from-scratch/issues/751) clarified this subtle difference, with even experienced practitioners spending time reconciling it.
This PR incorporates that context into the notebook so future readers can benefit directly, making the educational material more reader-friendly and avoiding unnecessary confusion.

### For detailed reference
Please check this link for detailed reference.

https://www.canva.com/design/DAGxyzsqYOk/1FUGwmxB4y-smDmNEKXj7A/edit?utm_content=DAGxyzsqYOk&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton

<img width="982" height="549" alt="スクリーンショット 2025-09-02 13 39 27" src="https://github.com/user-attachments/assets/6711be1b-4a01-4c62-9240-6dfc94d83c00" />