### PR TITLE
`Qwen3Tokenizer` fix for Qwen3 Base models and generation mismatch with HF

### DIFF
--- a/ch05/11_qwen3/README.md
+++ b/ch05/11_qwen3/README.md
@@ -45,8 +45,14 @@ pip install llms_from_scratch tokenizers
 Specify which model to use:
 
 ```python
-USE_REASONING_MODEL = False  # The base model
-USE_REASONING_MODEL = True   # The "thinking" model
+USE_REASONING_MODEL = True
+# Uses the base model if USE_REASONING_MODEL = False
+
+USE_INSTRUCT_MODEL = False
+# Uses the instruct mode (without reasoning) if 
+# USE_REASONING_MODEL = True
+# USE_INSTRUCT_MODEL = False
+# This setting does have no effect if USE_REASONING_MODEL = False
 
 
 # Use
@@ -187,10 +193,11 @@ else:
     tok_filename = "tokenizer-base.json"   
 
 tokenizer = Qwen3Tokenizer(
-    tokenizer_file_path=tok_filename,
+    tokenizer_file_path=tokenizer_file_path,
     repo_id=repo_id,
+    apply_chat_template=USE_REASONING_MODEL,
     add_generation_prompt=USE_REASONING_MODEL,
-    add_thinking=USE_REASONING_MODEL
+    add_thinking=not USE_INSTRUCT_MODEL
 )
 ```
 

--- a/ch05/11_qwen3/standalone-qwen3-moe-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-moe-plus-kvcache.ipynb
@@ -1064,6 +1064,7 @@
     "tokenizer = Qwen3Tokenizer(\n",
     "    tokenizer_file_path=tokenizer_file_path,\n",
     "    repo_id=repo_id,\n",
+    "    apply_chat_template=True,\n",
     "    add_generation_prompt=True,\n",
     "    add_thinking=True\n",
     ")"

--- a/ch05/11_qwen3/standalone-qwen3-moe-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-moe-plus-kvcache.ipynb
@@ -973,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -1000,7 +1000,6 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
-    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -1013,7 +1012,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if repo_id and \"Base\" not in repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -1021,7 +1020,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if chat_wrapped is None:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1240,7 +1239,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1254,7 +1253,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3-moe-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-moe-plus-kvcache.ipynb
@@ -973,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -1000,6 +1000,7 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
+    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -1012,7 +1013,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if repo_id and \"Base\" not in repo_id:\n",
+    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -1020,7 +1021,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None:\n",
+    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1239,7 +1240,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1253,7 +1254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3-moe.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-moe.ipynb
@@ -1006,6 +1006,7 @@
     "tokenizer = Qwen3Tokenizer(\n",
     "    tokenizer_file_path=tokenizer_file_path,\n",
     "    repo_id=repo_id,\n",
+    "    apply_chat_template=True,\n",
     "    add_generation_prompt=True,\n",
     "    add_thinking=True\n",
     ")"

--- a/ch05/11_qwen3/standalone-qwen3-moe.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-moe.ipynb
@@ -915,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -942,6 +942,7 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
+    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -954,7 +955,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if repo_id and \"Base\" not in repo_id:\n",
+    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -962,7 +963,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None:\n",
+    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1221,7 +1222,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1235,7 +1236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3-moe.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-moe.ipynb
@@ -915,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -942,7 +942,6 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
-    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -955,7 +954,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if repo_id and \"Base\" not in repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -963,7 +962,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if chat_wrapped is None:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1222,7 +1221,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1236,7 +1235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -987,7 +987,6 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
-    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -1000,7 +999,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if repo_id and \"Base\" not in repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -1008,7 +1007,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if chat_wrapped is None:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1207,7 +1206,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1221,7 +1220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -987,6 +987,7 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
+    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -999,7 +1000,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if repo_id and \"Base\" not in repo_id:\n",
+    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -1007,7 +1008,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None:\n",
+    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1206,7 +1207,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1220,7 +1221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
@@ -115,7 +115,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "USE_REASONING_MODEL = True"
+    "USE_REASONING_MODEL = True\n",
+    "# Uses the base model if USE_REASONING_MODEL = False\n",
+    "\n",
+    "USE_INSTRUCT_MODEL = False\n",
+    "# Uses the instruct mode (without reasoning) if \n",
+    "# USE_REASONING_MODEL = True\n",
+    "# USE_INSTRUCT_MODEL = False\n",
+    "# This setting does have no effect if USE_REASONING_MODEL = False"
    ]
   },
   {
@@ -1062,7 +1069,7 @@
     "    repo_id=repo_id,\n",
     "    apply_chat_template=USE_REASONING_MODEL,\n",
     "    add_generation_prompt=USE_REASONING_MODEL,\n",
-    "    add_thinking=USE_REASONING_MODEL\n",
+    "    add_thinking=not USE_INSTRUCT_MODEL\n",
     ")"
    ]
   },

--- a/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3-plus-kvcache.ipynb
@@ -1060,6 +1060,7 @@
     "tokenizer = Qwen3Tokenizer(\n",
     "    tokenizer_file_path=tokenizer_file_path,\n",
     "    repo_id=repo_id,\n",
+    "    apply_chat_template=USE_REASONING_MODEL,\n",
     "    add_generation_prompt=USE_REASONING_MODEL,\n",
     "    add_thinking=USE_REASONING_MODEL\n",
     ")"

--- a/ch05/11_qwen3/standalone-qwen3.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3.ipynb
@@ -902,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -929,6 +929,7 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
+    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -941,7 +942,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if repo_id and \"Base\" not in repo_id:\n",
+    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -949,7 +950,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None:\n",
+    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1141,7 +1142,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1155,7 +1156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3.ipynb
@@ -113,7 +113,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "USE_REASONING_MODEL = True"
+    "USE_REASONING_MODEL = True\n",
+    "# Uses the base model if USE_REASONING_MODEL = False\n",
+    "\n",
+    "USE_INSTRUCT_MODEL = False\n",
+    "# Uses the instruct mode (without reasoning) if \n",
+    "# USE_REASONING_MODEL = True\n",
+    "# USE_INSTRUCT_MODEL = False\n",
+    "# This setting does have no effect if USE_REASONING_MODEL = False"
    ]
   },
   {
@@ -1004,7 +1011,7 @@
     "    repo_id=repo_id,\n",
     "    apply_chat_template=USE_REASONING_MODEL,\n",
     "    add_generation_prompt=USE_REASONING_MODEL,\n",
-    "    add_thinking=USE_REASONING_MODEL\n",
+    "    add_thinking=not USE_INSTRUCT_MODEL\n",
     ")"
    ]
   },

--- a/ch05/11_qwen3/standalone-qwen3.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3.ipynb
@@ -902,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "b68ab489-48e5-471e-a814-56cda2d60f81",
    "metadata": {},
    "outputs": [],
@@ -929,7 +929,6 @@
     "        self.apply_chat_template = apply_chat_template\n",
     "        self.add_generation_prompt = add_generation_prompt\n",
     "        self.add_thinking = add_thinking\n",
-    "        self.repo_id=repo_id\n",
     "\n",
     "        tok_file = Path(tokenizer_file_path)\n",
     "        self._tok = Tokenizer.from_file(str(tok_file))\n",
@@ -942,7 +941,7 @@
     "        self.pad_token_id = self._special_to_id[\"<|endoftext|>\"]\n",
     "        self.eos_token_id = self.pad_token_id\n",
     "\n",
-    "        if self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if repo_id and \"Base\" not in repo_id:\n",
     "            eos_token = \"<|im_end|>\"\n",
     "        else:\n",
     "            eos_token = \"<|endoftext|>\"\n",
@@ -950,7 +949,7 @@
     "            self.eos_token_id = self._special_to_id[eos_token]\n",
     "\n",
     "    def encode(self, text, chat_wrapped=None):\n",
-    "        if chat_wrapped is None and self.repo_id and \"Base\" not in self.repo_id:\n",
+    "        if chat_wrapped is None:\n",
     "            chat_wrapped = self.apply_chat_template\n",
     "\n",
     "        stripped = text.strip()\n",
@@ -1142,7 +1141,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1156,7 +1155,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/ch05/11_qwen3/standalone-qwen3.ipynb
+++ b/ch05/11_qwen3/standalone-qwen3.ipynb
@@ -1002,6 +1002,7 @@
     "tokenizer = Qwen3Tokenizer(\n",
     "    tokenizer_file_path=tokenizer_file_path,\n",
     "    repo_id=repo_id,\n",
+    "    apply_chat_template=USE_REASONING_MODEL,\n",
     "    add_generation_prompt=USE_REASONING_MODEL,\n",
     "    add_thinking=USE_REASONING_MODEL\n",
     ")"

--- a/pkg/llms_from_scratch/qwen3.py
+++ b/pkg/llms_from_scratch/qwen3.py
@@ -531,6 +531,7 @@ class Qwen3Tokenizer:
         self.apply_chat_template = apply_chat_template
         self.add_generation_prompt = add_generation_prompt
         self.add_thinking = add_thinking
+        self.repo_id=repo_id
 
         tok_file = Path(tokenizer_file_path)
         if not tok_file.is_file() and repo_id:
@@ -549,7 +550,7 @@ class Qwen3Tokenizer:
         self.pad_token_id = self._special_to_id["<|endoftext|>"]
         self.eos_token_id = self.pad_token_id
 
-        if repo_id and "Base" not in repo_id:
+        if self.repo_id and "Base" not in self.repo_id:
             eos_token = "<|im_end|>"
         else:
             eos_token = "<|endoftext|>"
@@ -557,7 +558,7 @@ class Qwen3Tokenizer:
             self.eos_token_id = self._special_to_id[eos_token]
 
     def encode(self, text, chat_wrapped=None):
-        if chat_wrapped is None:
+        if chat_wrapped is None and self.repo_id and "Base" not in self.repo_id:
             chat_wrapped = self.apply_chat_template
 
         stripped = text.strip()

--- a/pkg/llms_from_scratch/qwen3.py
+++ b/pkg/llms_from_scratch/qwen3.py
@@ -531,7 +531,6 @@ class Qwen3Tokenizer:
         self.apply_chat_template = apply_chat_template
         self.add_generation_prompt = add_generation_prompt
         self.add_thinking = add_thinking
-        self.repo_id=repo_id
 
         tok_file = Path(tokenizer_file_path)
         if not tok_file.is_file() and repo_id:
@@ -550,7 +549,7 @@ class Qwen3Tokenizer:
         self.pad_token_id = self._special_to_id["<|endoftext|>"]
         self.eos_token_id = self.pad_token_id
 
-        if self.repo_id and "Base" not in self.repo_id:
+        if repo_id and "Base" not in repo_id:
             eos_token = "<|im_end|>"
         else:
             eos_token = "<|endoftext|>"
@@ -558,7 +557,7 @@ class Qwen3Tokenizer:
             self.eos_token_id = self._special_to_id[eos_token]
 
     def encode(self, text, chat_wrapped=None):
-        if chat_wrapped is None and self.repo_id and "Base" not in self.repo_id:
+        if chat_wrapped is None:
             chat_wrapped = self.apply_chat_template
 
         stripped = text.strip()

--- a/pkg/llms_from_scratch/tests/test_qwen3.py
+++ b/pkg/llms_from_scratch/tests/test_qwen3.py
@@ -457,21 +457,19 @@ def test_chat_wrap_and_equivalence(add_gen, add_think):
             add_thinking=add_think,
         )
 
-        # Our encode vs HF template
-        ours = qt.encode(prompt)
-        ref = hf_tok.apply_chat_template(
-            messages,
-            tokenize=True,
-            add_generation_prompt=add_gen,
-            enable_thinking=add_think,
-        )
-        ours = qt.encode(prompt)
-        ref = hf_tok.apply_chat_template(
-            messages,
-            tokenize=True,
-            add_generation_prompt=add_gen,
-            enable_thinking=add_think,
-        )
+        # Base models: compare raw encoding (no chat template)
+        if "Base" in repo_id:
+            ours = qt.encode(prompt)  # should use no chat template
+            ref = hf_tok.encode(prompt)  # raw encoding without chat template
+        else:
+            # Instruct models: compare with chat template
+            ours = qt.encode(prompt)  # will use chat template
+            ref = hf_tok.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=add_gen,
+                enable_thinking=add_think,
+            )
 
         if add_gen and not add_think:
             pass  # skip edge case as this is not something we use in practice

--- a/pkg/llms_from_scratch/tests/test_qwen3.py
+++ b/pkg/llms_from_scratch/tests/test_qwen3.py
@@ -457,19 +457,21 @@ def test_chat_wrap_and_equivalence(add_gen, add_think):
             add_thinking=add_think,
         )
 
-        # Base models: compare raw encoding (no chat template)
-        if "Base" in repo_id:
-            ours = qt.encode(prompt)  # should use no chat template
-            ref = hf_tok.encode(prompt)  # raw encoding without chat template
-        else:
-            # Instruct models: compare with chat template
-            ours = qt.encode(prompt)  # will use chat template
-            ref = hf_tok.apply_chat_template(
-                messages,
-                tokenize=True,
-                add_generation_prompt=add_gen,
-                enable_thinking=add_think,
-            )
+        # Our encode vs HF template
+        ours = qt.encode(prompt)
+        ref = hf_tok.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_gen,
+            enable_thinking=add_think,
+        )
+        ours = qt.encode(prompt)
+        ref = hf_tok.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_gen,
+            enable_thinking=add_think,
+        )
 
         if add_gen and not add_think:
             pass  # skip edge case as this is not something we use in practice

--- a/pkg/llms_from_scratch/tests/test_qwen3.py
+++ b/pkg/llms_from_scratch/tests/test_qwen3.py
@@ -20,7 +20,12 @@ from llms_from_scratch.kv_cache.generate import generate_text_simple as generate
 from llms_from_scratch.kv_cache_batched.qwen3 import Qwen3Model as Qwen3ModelKVBatched
 from llms_from_scratch.kv_cache_batched.generate import generate_text_simple as generate_text_simple_batched
 
+from llms_from_scratch.utils import download_file
+
 import importlib
+import os
+import shutil
+import tempfile
 import platform
 import pytest
 import torch
@@ -532,6 +537,72 @@ def test_multiturn_equivalence(repo_id, tok_file, add_gen, add_think):
     ours_dec = qt.decode(ours_ids)
     ref_dec = hf_tok.decode(ref_ids, skip_special_tokens=False)
     assert ours_dec == ref_dec
+
+
+@pytest.mark.skipif(not transformers_installed, reason="transformers not installed")
+def test_tokenizer_equivalence():
+    from transformers import AutoTokenizer
+
+    prompt = "Give me a short introduction to large language models."
+    messages = [
+        {"role": "user", "content": prompt},
+    ]
+
+    for apply_chat_template in (True, False):
+        for s in ("-Base", ""):
+            repo_id = f"Qwen/Qwen3-0.6B{s}"
+            tokenizer_ref = AutoTokenizer.from_pretrained(repo_id)
+            tokenizer_url = f"https://huggingface.co/Qwen/Qwen3-0.6B{s}/resolve/main/tokenizer.json"
+            download_file(tokenizer_url, out_dir=".")
+
+            old_name = "tokenizer.json"
+
+            if not s:
+                new_name = "tokenizer-reasoning.json"
+            else:
+                new_name = "tokenizer-base.json"
+
+            try:
+                shutil.move(old_name, new_name)
+            except Exception:
+                with tempfile.NamedTemporaryFile(delete=False, dir=".") as tmp_file:
+                    shutil.copyfile(old_name, tmp_file.name)
+                    os.replace(tmp_file.name, new_name)
+                os.remove(old_name)
+
+            for states in ((True, True), (False, False)):
+                tokenizer = Qwen3Tokenizer(
+                    tokenizer_file_path=new_name,
+                    repo_id=repo_id,
+                    apply_chat_template=apply_chat_template,
+                    add_generation_prompt=states[0],
+                    add_thinking=states[1]
+                )
+                input_token_ids = tokenizer.encode(prompt)
+
+                if apply_chat_template:
+                    input_token_ids_ref = tokenizer_ref.apply_chat_template(
+                        messages,
+                        tokenize=True,
+                        add_generation_prompt=states[0],
+                        enable_thinking=states[1],
+                    )
+                else:
+                    input_token_ids_ref = input_token_ids
+
+                assert input_token_ids == input_token_ids_ref, states
+
+                output_text = tokenizer.decode(input_token_ids)
+                out_text_ref = tokenizer_ref.decode(input_token_ids_ref)
+                assert output_text == out_text_ref, states
+
+                assert tokenizer.encode("<|endoftext|>") == [tokenizer._special_to_id["<|endoftext|>"]]
+                assert tokenizer.encode("<|im_end|>") == [tokenizer._special_to_id["<|im_end|>"]]
+
+                expected_eos_token = "<|im_end|>" if "base" not in new_name else "<|endoftext|>"
+                expected_pad_token = "<|endoftext|>"
+                assert tokenizer.decode([tokenizer.eos_token_id]) == expected_eos_token
+                assert tokenizer.decode([tokenizer.pad_token_id]) == expected_pad_token
 
 
 @pytest.mark.skipif(not transformers_installed, reason="transformers not installed")

--- a/pkg/llms_from_scratch/tests/test_qwen3.py
+++ b/pkg/llms_from_scratch/tests/test_qwen3.py
@@ -470,13 +470,6 @@ def test_chat_wrap_and_equivalence(add_gen, add_think):
             add_generation_prompt=add_gen,
             enable_thinking=add_think,
         )
-        ours = qt.encode(prompt)
-        ref = hf_tok.apply_chat_template(
-            messages,
-            tokenize=True,
-            add_generation_prompt=add_gen,
-            enable_thinking=add_think,
-        )
 
         if add_gen and not add_think:
             pass  # skip edge case as this is not something we use in practice

--- a/pkg/llms_from_scratch/utils.py
+++ b/pkg/llms_from_scratch/utils.py
@@ -9,6 +9,8 @@ import ast
 import re
 import types
 from pathlib import Path
+import urllib.request
+import urllib.parse
 
 import nbformat
 
@@ -122,3 +124,22 @@ def import_definitions_from_notebook(nb_dir_or_path, notebook_name=None, *, extr
 
     exec(src, mod.__dict__)
     return mod
+
+def download_file(url, out_dir="."):
+    """Simple file download utility for tests."""
+    from pathlib import Path
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    filename = Path(urllib.parse.urlparse(url).path).name
+    dest = out_dir / filename
+    
+    if dest.exists():
+        return dest
+        
+    try:
+        with urllib.request.urlopen(url) as response:
+            with open(dest, 'wb') as f:
+                f.write(response.read())
+        return dest
+    except Exception as e:
+        raise RuntimeError(f"Failed to download {url}: {e}")


### PR DESCRIPTION
Hello,

When using `USE_REASONING_MODEL = False` which default to `"{prefix}-Base"` variants, some prompts were giving weird generations, with `�` when decoded or Chinese tokens (with English prompts).

Which wasn't happening when comparing with HF.

The culprit seems to be that in `Qwen3Tokenizer` the `self.apply_chat_template` was still being applied to all `"{prefix}-Base"` models via `_wrap_chat()` despite you, already preventing it in the `if repo_id and "Base" not in repo_id:` check.

I've simply added an additional check in `encode()` to prevent special tokens like `"<|im_end|>"` to slip in when using Base models.

Some generations were fine but sometimes I guess the special SFT-like tokens were confusing the model since it's just Pretrained?
After testing, Base models now matches HF generations 1:1 for all tokens.

Feel free to modify or close this PR, if you prefer to do it differently