### PR TITLE
Simplify uv command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ bonus = [
     "safetensors>=0.6.2",
     "scikit-learn>=1.3.1",
     "sentencepiece>=0.1.99",
+    "thop",
     "tokenizers>=0.21.1",
     "transformers>=4.33.2",
     "tqdm>=4.65.0",

--- a/setup/01_optional-python-setup-preferences/README.md
+++ b/setup/01_optional-python-setup-preferences/README.md
@@ -173,7 +173,7 @@ uv pip install -r https://raw.githubusercontent.com/rasbt/LLMs-from-scratch/refs
 
 > **Optional dependencies for bonus materials:**
 > To include the optional dependencies used throughout the bonus materials, install the `bonus` dependency group from the project root:
->  `uv pip install --group bonus --editable .`
+>  `uv pip install --group bonus`
 > This is useful if you don't want to install them separately as you check out the optional bonus materials later on.
 
 <br>

--- a/setup/README.md
+++ b/setup/README.md
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 
 > **Note:** If you are running any of the notebooks on Google Colab and want to install the dependencies, simply run the following code in a new cell at the top of the notebook:
 > `pip install uv && uv pip install --system -r https://raw.githubusercontent.com/rasbt/LLMs-from-scratch/refs/heads/main/requirements.txt`
-> Optionally, after cloning the repository, you install the dependencies for all bonus materials with `uv pip install --group bonus --editable .` from the project root. This is useful if you don't want to install them separately as you check out the optional bonus materials later on.
+> Optionally, after cloning the repository, you install the dependencies for all bonus materials with `uv pip install --group bonus` from the project root. This is useful if you don't want to install them separately as you check out the optional bonus materials later on.
 
 
 


### PR DESCRIPTION
As discussed in #897, in newer `uv` versions, the `--editable .` is not necessary anymore when using the `--group` flag.