### PR TITLE
GatedDeltaNet code: Initialize A as the log of a uniform distribution

### DIFF
--- a/ch04/08_deltanet/README.md
+++ b/ch04/08_deltanet/README.md
@@ -166,7 +166,8 @@ class GatedDeltaNet(nn.Module):
         # A_log + W_alpha(x) + dt_bias
         self.W_alpha = nn.Linear(d_in, num_heads, bias=False)
         self.dt_bias = nn.Parameter(torch.ones(num_heads))
-        self.A_log = nn.Parameter(torch.zeros(num_heads))
+        A_init = torch.empty(num_heads).uniform_(0, 16)
+        self.A_log = nn.Parameter(torch.log(A_init))
         # We could implement this as
         # W_alpha = nn.Linear(d_in, num_heads, bias=True)
         # but the bias is separate for interpretability and


### PR DESCRIPTION
This is following #902 and spotted by @d-kleine:

Small refactor/fix to change the A component initialization from all zeroes to the log of a uniform distribution, following the official GDN implementations.

Note: I didn't specify the dtype of the `torch.empty` tensor for simplicity
