### PR TITLE
Optimized KV Cache (sliding window) bug fix

### DIFF
--- a/ch04/03_kv-cache/tests.py
+++ b/ch04/03_kv-cache/tests.py
@@ -9,7 +9,8 @@ from gpt_ch04 import generate_text_simple
 
 from gpt_with_kv_cache import GPTModel as GPTModelKV1
 from gpt_with_kv_cache_optimized import GPTModel as GPTModelKV2
-from gpt_with_kv_cache import generate_text_simple_cached
+from gpt_with_kv_cache import generate_text_simple_cached as generate_text_simple_cachedKV1
+from gpt_with_kv_cache_optimized import generate_text_simple_cached as generate_text_simple_cachedKV2
 
 
 GPT_CONFIG_124M = {
@@ -20,6 +21,7 @@ GPT_CONFIG_124M = {
     "n_layers": 12,
     "drop_rate": 0.1,
     "qkv_bias": False,
+    "kv_window_size": 1024  # NEW: KV cache window size
 }
 
 
@@ -80,8 +82,15 @@ def test_gpt_model_equivalence_cached(ModelClass):
             max_new_tokens=30,
             context_size=GPT_CONFIG_124M["context_length"]
         )
+    elif ModelClass is GPTModelKV1:
+        token_ids = generate_text_simple_cachedKV1(
+            model=model,
+            idx=encoded_tensor,
+            max_new_tokens=30,
+            context_size=GPT_CONFIG_124M["context_length"]
+        )
     else:
-        token_ids = generate_text_simple_cached(
+        token_ids = generate_text_simple_cachedKV2(
             model=model,
             idx=encoded_tensor,
             max_new_tokens=30,
@@ -99,3 +108,82 @@ def test_gpt_model_equivalence_cached(ModelClass):
             assert torch.equal(base_output, other_output), (
                 f"Mismatch between {base_name} and {other_name}"
             )
+
+
+def test_context_overflow_bug():
+    """
+    Test that demonstrates the ptr_current_pos overflow bug.
+
+    In old implementation:
+    - context_length = 10 (positions 0-9 available)
+    - We try to generate 15 tokens total (5 input + 10 generated)
+    - At token 11 (position 10), it crashes trying to access pos_emb[10]
+    """
+    GPT_CONFIG_SMALL = {
+        "vocab_size": 50257,
+        "context_length": 10,  # Very small context
+        "emb_dim": 768,
+        "n_heads": 12,
+        "n_layers": 12,
+        "drop_rate": 0.1,
+        "qkv_bias": False,
+        "kv_window_size": 20  # Larger than context_length
+    }
+
+    torch.manual_seed(123)
+
+    model = GPTModelKV2(GPT_CONFIG_SMALL).to(device)
+    model.eval()
+
+    # 5 input tokens
+    input_tokens = torch.randint(0, 50257, (1, 5), device=device)
+
+    generate_text_simple_cachedKV2(
+        model=model,
+        idx=input_tokens,
+        max_new_tokens=10,  # 5 + 10 = 15 > 10 context_length
+        context_size=GPT_CONFIG_SMALL["context_length"],
+        use_cache=True
+    )
+
+
+def test_prefill_chunking_basic():
+    """
+    Test that prefill correctly chunks input when input_length > kv_window_size.
+
+    Setup:
+    - kv_window_size = 4
+    - input_length = 10
+    - Should process in 3 chunks: [0:4], [4:8], [8:10]
+    """
+    config = {
+        "vocab_size": 50257,
+        "context_length": 20,
+        "emb_dim": 768,
+        "n_heads": 12,
+        "n_layers": 12,
+        "drop_rate": 0.1,
+        "qkv_bias": False,
+        "kv_window_size": 4  # Small window to force chunking
+    }
+
+    torch.manual_seed(123)
+    model = GPTModelKV2(config).to(device)
+    model.eval()
+
+    # 10 input tokens (> kv_window_size of 4)
+    input_tokens = torch.randint(0, 50257, (1, 10), device=device)
+
+    # Should successfully process all input in chunks
+    token_ids = generate_text_simple_cachedKV2(
+        model=model,
+        idx=input_tokens,
+        max_new_tokens=2,
+        use_cache=True
+    )
+
+    # Should have 10 input + 2 generated = 12 total
+    assert token_ids.shape[1] == 12, f"Expected 12 tokens, got {token_ids.shape[1]}"
+
+    # First 10 tokens should match input
+    assert torch.equal(token_ids[:, :10], input_tokens), "Input tokens should be preserved"


### PR DESCRIPTION
1. Fix bug because of KV cache and GPT's ptr pointer doesn't get reset when window_size > context_length
2. Fix bug because of KV cache and GPT's ptr pointer doesn't get reset
3. Fix unit test KV Cache import issue for gpt_with_kv_cache_optimized

 
<img width="1056" height="659" alt="2025-12-14_23-41-51" src="https://github.com/user-attachments/assets/483f9700-cf45-4810-942f-0c4e84266f85" />

<img width="1151" height="941" alt="2025-12-15_00-10-22" src="https://github.com/user-attachments/assets/b09caeae-f2c7-425a-8e68-dbac216bef78" />


