### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/basic-tests-latest-python.yml
+++ b/.github/workflows/basic-tests-latest-python.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 

--- a/.github/workflows/basic-tests-linux-uv.yml
+++ b/.github/workflows/basic-tests-linux-uv.yml
@@ -28,10 +28,10 @@ jobs:
     name: Code tests (Linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python (uv)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/basic-tests-macos-uv.yml
+++ b/.github/workflows/basic-tests-macos-uv.yml
@@ -28,10 +28,10 @@ jobs:
     name: Code tests (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python (uv)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/basic-tests-old-pytorch.yml
+++ b/.github/workflows/basic-tests-old-pytorch.yml
@@ -26,10 +26,10 @@ jobs:
         pytorch-version: [ 2.3.0, 2.5.0 ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 

--- a/.github/workflows/basic-tests-pip.yml
+++ b/.github/workflows/basic-tests-pip.yml
@@ -28,10 +28,10 @@ jobs:
     name: Pip Tests (Ubuntu Only)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"  # tests for backwards compatibility
 

--- a/.github/workflows/basic-tests-pixi.yml
+++ b/.github/workflows/basic-tests-pixi.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up pixi (without caching)
         uses: prefix-dev/setup-pixi@v0.8.2

--- a/.github/workflows/basic-tests-pytorch-rc.yml
+++ b/.github/workflows/basic-tests-pytorch-rc.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 

--- a/.github/workflows/basic-tests-windows-uv-pip.yml
+++ b/.github/workflows/basic-tests-windows-uv-pip.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
 

--- a/.github/workflows/check-spelling-errors.yml
+++ b/.github/workflows/check-spelling-errors.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/pep8-linter.yml
+++ b/.github/workflows/pep8-linter.yml
@@ -10,9 +10,9 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
     - name: Install ruff (a faster flake 8 equivalent)


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-pytorch-rc.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-old-pytorch.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/check-links.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-pip.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-pytorch-rc.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-linux-uv.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-windows-uv-pip.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/check-links.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/pep8-linter.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-pixi.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-latest-python.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-old-pytorch.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-pip.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-latest-python.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/pep8-linter.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/check-spelling-errors.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-macos-uv.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-linux-uv.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/check-spelling-errors.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/basic-tests-windows-uv-pip.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/basic-tests-macos-uv.yml`
