### PR TITLE
Fix enc_sample slicing to use first 50 tokens

### DIFF
--- a/ch02/01_main-chapter-code/ch02.ipynb
+++ b/ch02/01_main-chapter-code/ch02.ipynb
@@ -1193,12 +1193,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "e84424a7-646d-45b6-99e3-80d15fb761f2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "enc_sample = enc_text[50:]"
+    "enc_sample = enc_text[:50]"
    ]
   },
   {


### PR DESCRIPTION
Previously, enc_text[50:] skipped the first 50 tokens and returned the remaining tokens.
This change updates it to enc_text[:50] so enc_sample correctly contains the first 50 tokens for the input/output pair example.