### PR TITLE
Fix Gated Deltanet Bug: transpose of gate = gate.transpose(1, 2)

### DIFF
--- a/ch04/08_deltanet/README.md
+++ b/ch04/08_deltanet/README.md
@@ -206,7 +206,6 @@ class GatedDeltaNet(nn.Module):
         queries = queries.transpose(1, 2)
         values = values.transpose(1, 2)
         beta = beta.transpose(1, 2)
-        gate = gate.transpose(1, 2)  # NEW
 
         ####################################################
         ### NEW: QKNorm-like normalization for delta rule


### PR DESCRIPTION
In the Gated DeltaNet `README.md` I noticed probably a small bug: in the `GatedDeltaNet` forward method, using the `gate = gate.transpose(1, 2)` leads to the shape mismatch:


```
context = context * F.silu(gate)
     94 context = context.view(b, num_tokens, self.d_out)
     95 context = self.dropout(context)

RuntimeError: The size of tensor a (4) must match the size of tensor b (5) at non-singleton dimension 2
```

Removing the `gate = gate.transpose(1, 2)`  should fix the problem. 

Tested by the code:

```
batch_size = 2
seq_len = 5
d_in = 16
d_out = 32
num_heads = 4
dropout = 0.1

# Instantiate model
gated_deltanet = GatedDeltaNet(
    d_in=d_in,
    d_out=d_out,
    dropout=dropout,
    num_heads=num_heads
)

x = torch.randn(batch_size, seq_len, d_in)
print(gated_deltanet(x))
```