### PR TITLE
fix: add Apple MPS device detection to standalone Python scripts

### DIFF
--- a/ch04/03_kv-cache/gpt_ch04.py
+++ b/ch04/03_kv-cache/gpt_ch04.py
@@ -210,7 +210,12 @@ def main():
 
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
     model.eval()  # disable dropout
 

--- a/ch04/03_kv-cache/gpt_with_kv_cache.py
+++ b/ch04/03_kv-cache/gpt_with_kv_cache.py
@@ -318,7 +318,12 @@ def main():
 
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
     model.eval()  # disable dropout
 

--- a/ch04/03_kv-cache/gpt_with_kv_cache_optimized.py
+++ b/ch04/03_kv-cache/gpt_with_kv_cache_optimized.py
@@ -354,7 +354,12 @@ def main():
 
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
     model.eval()  # disable dropout
 

--- a/ch04/03_kv-cache/tests.py
+++ b/ch04/03_kv-cache/tests.py
@@ -25,7 +25,12 @@ GPT_CONFIG_124M = {
 }
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 
 @pytest.mark.parametrize("ModelClass", [GPTModelBase, GPTModelKV1, GPTModelKV2])

--- a/ch04/04_gqa/gpt_with_kv_gqa.py
+++ b/ch04/04_gqa/gpt_with_kv_gqa.py
@@ -315,7 +315,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/04_gqa/gpt_with_kv_mha.py
+++ b/ch04/04_gqa/gpt_with_kv_mha.py
@@ -301,7 +301,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/05_mla/gpt_with_kv_mha.py
+++ b/ch04/05_mla/gpt_with_kv_mha.py
@@ -301,7 +301,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/05_mla/gpt_with_kv_mla.py
+++ b/ch04/05_mla/gpt_with_kv_mla.py
@@ -312,7 +312,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/06_swa/gpt_with_kv_mha.py
+++ b/ch04/06_swa/gpt_with_kv_mha.py
@@ -301,7 +301,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/06_swa/gpt_with_kv_swa.py
+++ b/ch04/06_swa/gpt_with_kv_swa.py
@@ -346,7 +346,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/07_moe/gpt_with_kv_ffn.py
+++ b/ch04/07_moe/gpt_with_kv_ffn.py
@@ -371,7 +371,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/07_moe/gpt_with_kv_moe.py
+++ b/ch04/07_moe/gpt_with_kv_moe.py
@@ -446,7 +446,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/09_dsa/gpt_with_kv_dsa.py
+++ b/ch04/09_dsa/gpt_with_kv_dsa.py
@@ -451,7 +451,12 @@ def main():
 
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/10_kv-sharing/gpt_with_kv_mha.py
+++ b/ch04/10_kv-sharing/gpt_with_kv_mha.py
@@ -304,7 +304,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch04/10_kv-sharing/gpt_with_kv_sharing.py
+++ b/ch04/10_kv-sharing/gpt_with_kv_sharing.py
@@ -323,7 +323,12 @@ def main():
     }
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device, dtype=torch.bfloat16)
     model.eval()  # disable dropout
 

--- a/ch05/01_main-chapter-code/gpt_train.py
+++ b/ch05/01_main-chapter-code/gpt_train.py
@@ -131,7 +131,12 @@ def plot_losses(epochs_seen, tokens_seen, train_losses, val_losses):
 def main(gpt_config, settings):
 
     torch.manual_seed(123)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     ##############################
     # Download data if necessary

--- a/ch05/03_bonus_pretraining_on_gutenberg/pretraining_simple.py
+++ b/ch05/03_bonus_pretraining_on_gutenberg/pretraining_simple.py
@@ -193,7 +193,12 @@ if __name__ == "__main__":
             "qkv_bias": False        # Query-key-value bias
         }
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     torch.manual_seed(123)
     model = GPTModel(GPT_CONFIG_124M)
     model.to(device)

--- a/ch05/05_bonus_hparam_tuning/hparam_search.py
+++ b/ch05/05_bonus_hparam_tuning/hparam_search.py
@@ -127,7 +127,12 @@ if __name__ == "__main__":
         text_data = file.read()
 
     tokenizer = tiktoken.get_encoding("gpt2")
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     train_ratio = 0.95
     split_idx = int(train_ratio * len(text_data))

--- a/ch05/06_user_interface/app_orig.py
+++ b/ch05/06_user_interface/app_orig.py
@@ -18,7 +18,12 @@ from llms_from_scratch.ch05 import (
     token_ids_to_text,
 )
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 
 def get_model_and_tokenizer():

--- a/ch05/06_user_interface/app_own.py
+++ b/ch05/06_user_interface/app_own.py
@@ -20,7 +20,12 @@ from llms_from_scratch.ch05 import (
 )
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 
 def get_model_and_tokenizer():

--- a/ch05/18_muon/gpt_train.py
+++ b/ch05/18_muon/gpt_train.py
@@ -131,7 +131,12 @@ def plot_losses(epochs_seen, tokens_seen, train_losses, val_losses):
 def main(gpt_config, settings):
 
     torch.manual_seed(123)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     ##############################
     # Download data if necessary

--- a/ch05/18_muon/gpt_train_muon.py
+++ b/ch05/18_muon/gpt_train_muon.py
@@ -175,7 +175,12 @@ def plot_losses(epochs_seen, tokens_seen, train_losses, val_losses):
 def main(gpt_config, settings):
 
     torch.manual_seed(123)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     ##############################
     # Download data if necessary

--- a/ch06/01_main-chapter-code/gpt_class_finetune.py
+++ b/ch06/01_main-chapter-code/gpt_class_finetune.py
@@ -381,7 +381,12 @@ if __name__ == "__main__":
 
         model = GPTModel(BASE_CONFIG)
         load_weights_into_gpt(model, params)
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")
 
     ########################################
     # Modify and pretrained model

--- a/ch06/02_bonus_additional-experiments/additional_experiments.py
+++ b/ch06/02_bonus_additional-experiments/additional_experiments.py
@@ -596,7 +596,12 @@ if __name__ == "__main__":
     else:
         raise ValueError("Invalid --trainable_layers argument.")
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
 
     ###############################

--- a/ch06/03_bonus_imdb-classification/train_bert_hf.py
+++ b/ch06/03_bonus_imdb-classification/train_bert_hf.py
@@ -358,7 +358,12 @@ if __name__ == "__main__":
     else:
         raise ValueError("Selected --model {args.model} not supported.")
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
     model.eval()
 

--- a/ch06/03_bonus_imdb-classification/train_bert_hf_spam.py
+++ b/ch06/03_bonus_imdb-classification/train_bert_hf_spam.py
@@ -395,7 +395,12 @@ if __name__ == "__main__":
     else:
         raise ValueError("Selected --model {args.model} not supported.")
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
     model.eval()
 

--- a/ch06/03_bonus_imdb-classification/train_gpt.py
+++ b/ch06/03_bonus_imdb-classification/train_gpt.py
@@ -352,7 +352,12 @@ if __name__ == "__main__":
     else:
         raise ValueError("Invalid --trainable_layers argument.")
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
 
     if args.compile:

--- a/ch06/03_bonus_imdb-classification/train_gpt_muon.py
+++ b/ch06/03_bonus_imdb-classification/train_gpt_muon.py
@@ -397,7 +397,12 @@ if __name__ == "__main__":
     else:
         raise ValueError("Invalid --trainable_layers argument.")
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     model.to(device)
 
     if args.compile:

--- a/ch06/04_user_interface/app.py
+++ b/ch06/04_user_interface/app.py
@@ -16,7 +16,12 @@ from llms_from_scratch.ch04 import GPTModel
 from llms_from_scratch.ch06 import classify_review
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 
 def get_model_and_tokenizer():

--- a/ch07/01_main-chapter-code/exercise_experiments.py
+++ b/ch07/01_main-chapter-code/exercise_experiments.py
@@ -334,7 +334,12 @@ def main(mask_instructions=False, alpaca52k=False, phi3_prompt=False, lora=False
     print(50*"-")
 
     tokenizer = tiktoken.get_encoding("gpt2")
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     print("Device:", device)
     print(50*"-")
 

--- a/ch07/01_main-chapter-code/gpt_instruction_finetuning.py
+++ b/ch07/01_main-chapter-code/gpt_instruction_finetuning.py
@@ -186,7 +186,12 @@ def main(test_mode=False):
     print(50*"-")
 
     tokenizer = tiktoken.get_encoding("gpt2")
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     print("Device:", device)
     print(50*"-")
 

--- a/ch07/06_user_interface/app.py
+++ b/ch07/06_user_interface/app.py
@@ -20,7 +20,12 @@ from llms_from_scratch.ch05 import (
     token_ids_to_text,
 )
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 
 def get_model_and_tokenizer():

--- a/pkg/llms_from_scratch/tests/test_appendix_d.py
+++ b/pkg/llms_from_scratch/tests/test_appendix_d.py
@@ -35,7 +35,12 @@ def test_train(tmp_path):
     }
 
     torch.manual_seed(123)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     ##############################
     # Download data if necessary

--- a/pkg/llms_from_scratch/tests/test_ch05.py
+++ b/pkg/llms_from_scratch/tests/test_ch05.py
@@ -37,7 +37,12 @@ OTHER_SETTINGS = {
 @pytest.mark.parametrize("ModelClass", [GPTModel, GPTModelFast])
 def test_train_simple(tmp_path, ModelClass):
     torch.manual_seed(123)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     ##############################
     # Download data if necessary

--- a/pkg/llms_from_scratch/tests/test_ch07.py
+++ b/pkg/llms_from_scratch/tests/test_ch07.py
@@ -38,7 +38,12 @@ def test_instruction_finetune(tmp_path):
     test_data = test_data[:15]
 
     tokenizer = tiktoken.get_encoding("gpt2")
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     customized_collate_fn = partial(custom_collate_fn, device=device, allowed_max_length=100)
 


### PR DESCRIPTION
## Summary

Addresses #977.

The standalone `.py` scripts in ch04–ch07, `pkg/`, and tests used the two-way CUDA-or-CPU device check:

```python
device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
```

This silently falls back to CPU on Apple Silicon (M1/M2/M3/M4) even though MPS acceleration is available. The Jupyter notebooks already handle MPS — this PR brings the `.py` scripts in line.

## Changes

Updated 35 Python scripts to the three-way device check:

```python
if torch.cuda.is_available():
    device = torch.device("cuda")
elif torch.backends.mps.is_available():
    device = torch.device("mps")
else:
    device = torch.device("cpu")
```

**Excluded (as discussed in #977):**
- `ch05/10_llm-training-speed/` — multi-GPU training scripts
- Appendix-A DDP scripts — DDP is inherently CUDA-only
- Jupyter notebooks — already have MPS support

## Files changed

35 files across ch04, ch05, ch06, ch07, and pkg/llms_from_scratch/tests.

Fixes #977