### PR TITLE
Fix GPT-2 KV-cache generation

### DIFF
--- a/pkg/llms_from_scratch/kv_cache/gpt2.py
+++ b/pkg/llms_from_scratch/kv_cache/gpt2.py
@@ -55,7 +55,7 @@ class MultiHeadAttention(nn.Module):
 
         seq_len = keys.size(2)
         causal_mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool, device=x.device), diagonal=1)
-        causal_mask = causal_mask[:, -num_tokens:][None, None, :, :]
+        causal_mask = causal_mask[-num_tokens:, :][None, None, :, :]
 
         # Compute scaled dot-product attention (aka self-attention) with a causal mask
         attn_scores = queries @ keys.transpose(2, 3)  # Dot product for each head
@@ -153,6 +153,7 @@ class TransformerBlock(nn.Module):
 class GPTModel(nn.Module):
     def __init__(self, cfg):
         super().__init__()
+        self.cfg = cfg
         self.tok_emb = nn.Embedding(cfg["vocab_size"], cfg["emb_dim"])
         self.pos_emb = nn.Embedding(cfg["context_length"], cfg["emb_dim"])
         self.drop_emb = nn.Dropout(cfg["drop_rate"])
@@ -165,17 +166,16 @@ class GPTModel(nn.Module):
         self.current_pos = 0
 
     def forward(self, in_idx, use_cache=False, cache=None):
+        use_cache = use_cache or cache is not None
         batch_size, seq_len = in_idx.shape
-        pos = torch.arange(self.current_pos, self.current_pos + seq_len, device=in_idx.device)
+        start_pos = self.current_pos if use_cache else 0
+        pos = torch.arange(start_pos, start_pos + seq_len, device=in_idx.device)
         tok_embeds = self.tok_emb(in_idx)
         pos_embeds = self.pos_emb(pos)
         x = self.drop_emb(tok_embeds + pos_embeds)
 
         if use_cache:
-            start_pos = self.current_pos
             self.current_pos += seq_len
-        else:
-            start_pos = 0
 
         for i, block in enumerate(self.trf_blocks):
             blk_cache = cache.get(i) if cache else None
@@ -186,3 +186,6 @@ class GPTModel(nn.Module):
         x = self.final_norm(x)
         logits = self.out_head(x)
         return logits
+
+    def reset_kv_cache(self):
+        self.current_pos = 0

--- a/pkg/llms_from_scratch/tests/test_kv_cache_gpt2.py
+++ b/pkg/llms_from_scratch/tests/test_kv_cache_gpt2.py
@@ -1,0 +1,128 @@
+# Copyright (c) Sebastian Raschka under Apache License 2.0 (see LICENSE.txt).
+
+import pytest
+import torch
+
+from llms_from_scratch.kv_cache.generate import generate_text_simple, generate_text_simple_stream
+from llms_from_scratch.kv_cache.gpt2 import GPTModel
+from llms_from_scratch.kv_cache.utils import KVCache
+
+
+TEST_CONFIG = {
+    "vocab_size": 96,
+    "context_length": 16,
+    "emb_dim": 32,
+    "n_heads": 4,
+    "n_layers": 2,
+    "drop_rate": 0.0,
+    "qkv_bias": False,
+}
+
+
+def make_model(seed=123):
+    torch.manual_seed(seed)
+    return GPTModel(TEST_CONFIG).eval()
+
+
+def test_model_exposes_cached_generator_contract():
+    model = make_model()
+
+    assert model.cfg == TEST_CONFIG
+    model.current_pos = 7
+    model.reset_kv_cache()
+    assert model.current_pos == 0
+
+
+def test_supplied_cache_activates_cache_path_and_supports_a_second_step():
+    model = make_model()
+    cache = KVCache(n_layers=TEST_CONFIG["n_layers"])
+    prompt = torch.tensor([[4, 8, 15, 16]])
+
+    logits = model(prompt, cache=cache)
+
+    assert logits.shape == (1, 4, TEST_CONFIG["vocab_size"])
+    assert model.current_pos == prompt.shape[1]
+    for keys, values in cache.get_all():
+        assert keys.shape[2] == prompt.shape[1]
+        assert values.shape[2] == prompt.shape[1]
+
+    next_token = logits[:, -1].argmax(dim=-1, keepdim=True)
+    next_logits = model(next_token, cache=cache)
+
+    assert next_logits.shape == (1, 1, TEST_CONFIG["vocab_size"])
+    assert model.current_pos == prompt.shape[1] + 1
+    for keys, values in cache.get_all():
+        assert keys.shape[2] == prompt.shape[1] + 1
+        assert values.shape[2] == prompt.shape[1] + 1
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("prompt_length", [1, 4, 8])
+def test_cached_generation_matches_uncached(batch_size, prompt_length):
+    model = make_model()
+    prompt = torch.randint(0, TEST_CONFIG["vocab_size"], (batch_size, prompt_length))
+
+    uncached = generate_text_simple(
+        model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=False
+    )
+    cached = generate_text_simple(
+        model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=True
+    )
+
+    assert torch.equal(cached, uncached)
+
+
+def test_uncached_generation_does_not_inherit_cache_position():
+    model = make_model(seed=321)
+    prompt = torch.tensor([[4, 8, 15, 16]])
+
+    generate_text_simple(
+        model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=True
+    )
+    observed = generate_text_simple(
+        model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=False
+    )
+
+    fresh_model = GPTModel(TEST_CONFIG).eval()
+    fresh_model.load_state_dict(model.state_dict())
+    expected = generate_text_simple(
+        fresh_model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=False
+    )
+
+    assert torch.equal(observed, expected)
+
+
+def test_repeated_cached_generation_resets_position_state():
+    model = make_model()
+    prompt = torch.tensor([[4, 8, 15, 16]])
+
+    first = generate_text_simple(
+        model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=True
+    )
+    second = generate_text_simple(
+        model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=True
+    )
+
+    assert torch.equal(first, second)
+
+
+def test_streaming_generation_matches_cached_generation():
+    reference_model = make_model()
+    streaming_model = make_model()
+    streaming_model.load_state_dict(reference_model.state_dict())
+    prompt = torch.tensor([[4, 8, 15, 16]])
+
+    expected = generate_text_simple(
+        reference_model, prompt.clone(), max_new_tokens=3, context_size=16, use_cache=True
+    )
+    streamed_tokens = list(
+        generate_text_simple_stream(
+            streaming_model,
+            prompt.clone(),
+            max_new_tokens=3,
+            context_size=16,
+        )
+    )
+    observed = torch.cat([prompt, *streamed_tokens], dim=1)
+
+    assert torch.equal(observed, expected)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ bonus = [
 line-length = 140
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 exclude = [".venv"]
 ignore = [
     "C406", "E226", "E402", "E702", "E703",


### PR DESCRIPTION
## Summary

- make the packaged GPT-2 model satisfy the shared KV-cache generator contract
- activate cached execution whenever a cache object is supplied
- fix causal-mask row selection for incremental cached decoding
- keep cached position state from affecting uncached inference
- add a deterministic, lightweight regression suite covering the complete failure chain

## Root cause

The shared cached generator expects `model.cfg` and `model.reset_kv_cache()`, but the packaged GPT-2 implementation exposed neither. Supplying a cache also did not activate the cached path. Once caching was activated directly, the causal mask sliced key columns instead of query rows, so the second incremental step failed with a broadcast error. Finally, cached positional state was reused by later uncached calls.

## Regression coverage

The new focused test file covers:

- the model/generator interface contract
- cache activation from the cache argument
- successful second-step decoding and per-layer cache growth
- exact cached-versus-uncached output equality across two batch sizes and three prompt lengths
- isolation of uncached inference after a cached call
- deterministic repeated cached generation
- parity between streaming and non-streaming cached generation

The tests use a tiny randomly initialized model and require no tokenizer, downloads, or pretrained weights.

## Validation

```text
pkg/llms_from_scratch/tests/test_kv_cache_gpt2.py
11 passed

pkg/llms_from_scratch/tests/test_ch04.py + test_kv_cache_gpt2.py
17 passed
```

The independent reproduction and 30-case exact-equivalence matrix are available in [Phason Evidence Audit PEA-006](https://github.com/AparajeetS/PEA-006-llms-kv-cache).

## Scope

This PR does not add cache eviction when generation exceeds the configured positional context window; that remains an explicit existing boundary.
