### PR TITLE
fix: preserve whitespace in SimpleTokenizer

### DIFF
--- a/ch02/01_main-chapter-code/ch02.ipynb
+++ b/ch02/01_main-chapter-code/ch02.ipynb
@@ -412,7 +412,7 @@
    ],
    "source": [
     "preprocessed = re.split(r'([,.:;?_!\"()\\']|--|\\s)', raw_text)\n",
-    "preprocessed = [item.strip() for item in preprocessed if item.strip()]\n",
+    "preprocessed = [item for item in preprocessed if item]\n",
     "print(preprocessed[:30])"
    ]
   },
@@ -624,16 +624,12 @@
     "    def encode(self, text):\n",
     "        preprocessed = re.split(r'([,.:;?_!\"()\\']|--|\\s)', text)\n",
     "                                \n",
-    "        preprocessed = [\n",
-    "            item.strip() for item in preprocessed if item.strip()\n",
-    "        ]\n",
+    "        preprocessed = [item for item in preprocessed if item]\n",
     "        ids = [self.str_to_int[s] for s in preprocessed]\n",
     "        return ids\n",
     "        \n",
     "    def decode(self, ids):\n",
-    "        text = \" \".join([self.int_to_str[i] for i in ids])\n",
-    "        # Replace spaces before the specified punctuations\n",
-    "        text = re.sub(r'\\s+([,.?!\"()\\'])', r'\\1', text)\n",
+    "        text = \"\".join([self.int_to_str[i] for i in ids])\n",
     "        return text"
    ]
   },
@@ -921,7 +917,7 @@
     "    \n",
     "    def encode(self, text):\n",
     "        preprocessed = re.split(r'([,.:;?_!\"()\\']|--|\\s)', text)\n",
-    "        preprocessed = [item.strip() for item in preprocessed if item.strip()]\n",
+    "        preprocessed = [item for item in preprocessed if item]\n",
     "        preprocessed = [\n",
     "            item if item in self.str_to_int \n",
     "            else \"<|unk|>\" for item in preprocessed\n",
@@ -931,9 +927,7 @@
     "        return ids\n",
     "        \n",
     "    def decode(self, ids):\n",
-    "        text = \" \".join([self.int_to_str[i] for i in ids])\n",
-    "        # Replace spaces before the specified punctuations\n",
-    "        text = re.sub(r'\\s+([,.:;?!\"()\\'])', r'\\1', text)\n",
+    "        text = \"\".join([self.int_to_str[i] for i in ids])\n",
     "        return text"
    ]
   },


### PR DESCRIPTION
## Summary\n\nFixes #1017.\n\nSimpleTokenizerV1 and SimpleTokenizerV2 currently strip whitespace tokens during encoding and rebuild decoded text by joining tokens with spaces. This changes the input text for cases such as hello--world, newlines, and repeated spaces.\n\nThis change:\n\n- keeps the whitespace captured by the tokenizer's existing regular expression;\n- filters only empty strings;\n- reconstructs decoded text by joining the original tokens directly;\n- preserves <|unk|> handling in SimpleTokenizerV2.\n\nThe vocabulary-building example is updated to use the same tokenization rule, so the whitespace tokens are available during encoding.\n\n## Validation\n\n- Verified decode(encode(text)) == text for source text, punctuation, --, newlines, and repeated spaces.\n- Verified unknown words still decode as <|unk|> in SimpleTokenizerV2.\n- jq empty ch02/01_main-chapter-code/ch02.ipynb\n- git diff --check\n\nAI assistance was used for repository research, implementation, and test drafting. I reviewed the final diff and validation results.