### PR TITLE
Fix wording in optional dependency setup note

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 
 > **Note:** If you are running any of the notebooks on Google Colab and want to install the dependencies, simply run the following code in a new cell at the top of the notebook:
 > `pip install uv && uv pip install --system -r https://raw.githubusercontent.com/rasbt/LLMs-from-scratch/refs/heads/main/requirements.txt`
-> Optionally, after cloning the repository, you install the dependencies for all bonus materials with `uv pip install --group bonus` from the project root. This is useful if you don't want to install them separately as you check out the optional bonus materials later on.
+> Optionally, after cloning the repository, you can install the dependencies for all bonus materials with `uv pip install --group bonus` from the project root. This is useful if you don't want to install them separately as you check out the optional bonus materials later on.
 
 
 


### PR DESCRIPTION
## Summary

- add the missing modal verb in the optional dependency installation note
- keep the documented command and meaning unchanged

## Validation

- confirmed the Markdown heading and code-fence counts are unchanged
- `git diff --check`